### PR TITLE
feat: add basic streetrace

### DIFF
--- a/public_html/app/Resources/Views/gamebase.twig
+++ b/public_html/app/Resources/Views/gamebase.twig
@@ -197,7 +197,7 @@
                         <li><a href="{{ routing.getRouteByRouteName('drugs-liquids') }}"><span class="hideMobile il">- </span>{{ langs.DRUGS_LIQUIDS }}<span class="hideDesktop il"> -</span></a></li>
                         <li><a href="{{ routing.getRouteByRouteName('smuggling') }}"><span class="hideMobile il">- </span>{{ langs.SMUGGLING }}<span class="hideDesktop il"> -</span></a></li>
                         <li><a href="{{ routing.getRouteByRouteName('garage') }}"><span class="hideMobile il">- </span>Garage<span class="hideDesktop il"> -</span></a></li>
-                        {# <li><a href="{{ routing.getRouteByRouteName('streetrace') }}"><span class="hideMobile il">- </span>Streetrace<span class="hideDesktop il"> -</span></a></li> #}
+                        <li><a href="{{ routing.getRouteByRouteName('streetrace') }}"><span class="hideMobile il">- </span>Streetrace<span class="hideDesktop il"> -</span></a></li>
                     </ul>
                 </li>
                 <li>

--- a/public_html/app/config/routes/ajax.routes.php
+++ b/public_html/app/config/routes/ajax.routes.php
@@ -757,6 +757,13 @@ array(
         'route' => '/game/racetrack/play',
         'controller' => "Ajax/racetrack.play.php"
     ),
+
+    'play-streetrace'
+    =>
+    array(
+        'route' => '/game/streetrace/play',
+        'controller' => 'Ajax/streetrace.play.php'
+    ),
     
     'play-roulette'
     =>

--- a/public_html/src/Business/StreetraceService.php
+++ b/public_html/src/Business/StreetraceService.php
@@ -1,0 +1,134 @@
+<?PHP
+
+namespace src\Business;
+
+use app\config\Routing;
+use src\Data\StreetraceDAO;
+
+class StreetraceService
+{
+    private $data;
+    public $raceTypes = array(
+        'highway' => 'Highway',
+        'route66' => 'Route66',
+        'drift' => 'Drift Race',
+        'city' => 'City Race'
+    );
+
+    public function __construct()
+    {
+        $this->data = new StreetraceDAO();
+    }
+
+    public function __destruct()
+    {
+        $this->data = null;
+    }
+
+    public function race($post)
+    {
+        global $security;
+        global $userData;
+        global $language;
+        global $route;
+        global $langs;
+        $l = $language->streetraceLangs();
+
+        $stake = (int)$post['stake'];
+        $type = isset($post['type']) ? $post['type'] : '';
+        $vehicleId = (int)$post['vehicle'];
+
+        if($security->checkToken($post['security-token']) == false)
+            $error = $langs['INVALID_SECURITY_TOKEN'];
+        if($userData->getInPrison())
+            $error = $langs['CANT_DO_THAT_IN_PRISON'];
+        if($userData->getTraveling())
+            $error = $langs['CANT_DO_THAT_TRAVELLING'];
+        if(!array_key_exists($type, $this->raceTypes))
+            $error = $l['INVALID_RACE_TYPE'];
+        if($stake < 1)
+            $error = $l['INVALID_STAKE'];
+        if($userData->getCash() < $stake)
+            $error = $langs['NOT_ENOUGH_MONEY_CASH'];
+        if(($vehicle = $this->data->getUserVehicle($vehicleId)) == false)
+            $error = $l['INVALID_VEHICLE'];
+
+        if(isset($error))
+            return Routing::errorMessage($error);
+
+        $playerScore = $this->calculateScore($vehicle, $type);
+        $scores = array(
+            $userData->getUsername() => $playerScore,
+            'Opponent 1' => $this->randomScore($type),
+            'Opponent 2' => $this->randomScore($type),
+            'Opponent 3' => $this->randomScore($type)
+        );
+        arsort($scores);
+        $position = array_search($userData->getUsername(), array_keys($scores)) + 1;
+
+        $profit = -$stake;
+        if($position === 1)
+            $profit += $stake * 3;
+        elseif($position === 2)
+            $profit += $stake;
+
+        $this->data->updateUserCash($profit);
+
+        if($position === 1)
+        {
+            $msg = $route->replaceMessagePart(number_format($stake * 3, 0, '', ','), $l['RACE_SUCCESS_WON_FIRST'], '/{price}/');
+            return Routing::successMessage($msg);
+        }
+        elseif($position === 2)
+        {
+            return Routing::successMessage($l['RACE_SUCCESS_EVEN_SECOND']);
+        }
+        else
+        {
+            $msg = $route->replaceMessagePart($position, $l['RACE_SUCCESS_LOST_NTH'], '/{nth}/');
+            return Routing::errorMessage($msg);
+        }
+    }
+
+    private function calculateScore($vehicle, $type)
+    {
+        global $security;
+        $hp = $vehicle['horsepower'];
+        $ts = $vehicle['topspeed'];
+        $ac = $vehicle['acceleration'];
+        $ct = $vehicle['control'];
+        $br = $vehicle['breaking'];
+
+        switch($type)
+        {
+            case 'highway':
+                $score = $ts * 2 + $hp + $ac;
+                break;
+            case 'route66':
+                $score = $hp * 2 + $ts + $ac;
+                break;
+            case 'drift':
+                $score = $ct * 2 + $br + $ac;
+                break;
+            case 'city':
+            default:
+                $score = $ac * 2 + $ct + $br;
+                break;
+        }
+        $score += $security->randInt(0, 100);
+        return $score;
+    }
+
+    private function randomScore($type)
+    {
+        global $security;
+        $vehicle = array(
+            'horsepower' => $security->randInt(200, 800),
+            'topspeed' => $security->randInt(200, 350),
+            'acceleration' => $security->randInt(20, 80),
+            'control' => $security->randInt(10, 100),
+            'breaking' => $security->randInt(10, 100)
+        );
+        return $this->calculateScore($vehicle, $type);
+    }
+}

--- a/public_html/src/Controllers/Ajax/streetrace.play.php
+++ b/public_html/src/Controllers/Ajax/streetrace.play.php
@@ -1,0 +1,16 @@
+<?PHP
+
+use src\Business\StreetraceService;
+
+require_once __DIR__ . '/.inc.head.ajax.php';
+
+if(isset($_POST['security-token']) && isset($_POST['vehicle']) && isset($_POST['stake']) && isset($_POST['type']))
+{
+    $streetrace = new StreetraceService();
+    $response = $streetrace->race($_POST);
+
+    require_once __DIR__ . '/.inc.foot.ajax.php';
+    $twigVars['langs'] = array_merge($twigVars['langs'], $language->streetraceLangs());
+    $twigVars['response'] = $response;
+    print_r($twig->render('/src/Views/game/Ajax/streetrace.twig', $twigVars));
+}

--- a/public_html/src/Controllers/game/streetrace.php
+++ b/public_html/src/Controllers/game/streetrace.php
@@ -1,9 +1,18 @@
 <?PHP
 
+use src\Business\GarageService;
+use src\Business\StreetraceService;
+
 require_once __DIR__ . '/.inc.head.php';
+
+$garage = new GarageService();
+$vehicles = $garage->getAllVehiclesInGarageByState($userData->getStateID());
+$streetrace = new StreetraceService();
 
 require_once __DIR__ . '/.inc.foot.php';
 
-//$twigVars['langs'] = array_merge($twigVars['langs'], $language->statusLangs()); // Extend base langs
+$twigVars['langs'] = array_merge($twigVars['langs'], $language->streetraceLangs());
+$twigVars['vehicles'] = $vehicles;
+$twigVars['raceTypes'] = $streetrace->raceTypes;
 
 print_r($twig->render('/src/Views/game/streetrace.twig', $twigVars));

--- a/public_html/src/Data/StreetraceDAO.php
+++ b/public_html/src/Data/StreetraceDAO.php
@@ -1,0 +1,60 @@
+<?PHP
+
+namespace src\Data;
+
+use src\Business\GarageService;
+use src\Data\config\DBConfig;
+
+class StreetraceDAO extends DBConfig
+{
+    protected $con = "";
+    private $dbh = "";
+
+    public function __construct()
+    {
+        global $connection;
+        $this->con = $connection;
+        $this->dbh = $connection->con;
+    }
+
+    public function __destruct()
+    {
+        $this->dbh = null;
+    }
+
+    public function getUserVehicle($garageId)
+    {
+        if(isset($_SESSION['UID']))
+        {
+            $statement = $this->dbh->prepare("SELECT g.`id`, v.`horsepower`, v.`topspeed`, v.`acceleration`, v.`control`, v.`breaking`, g.`tires`, g.`engine`, g.`exhaust`, g.`shockAbsorbers` FROM `garage` AS g LEFT JOIN `user_garage` AS ug ON (g.`userGarageID` = ug.`id`) LEFT JOIN `vehicle` AS v ON (g.`vehicleID` = v.`id`) WHERE g.`id` = :gid AND ug.`userID` = :uid AND g.`active`='1' AND g.`deleted`='0' AND v.`active`='1' AND v.`deleted`='0'");
+            $statement->execute(array(':gid' => $garageId, ':uid' => $_SESSION['UID']));
+            $row = $statement->fetch();
+            if(isset($row['id']))
+            {
+                $garageService = new GarageService();
+                foreach(array_keys($garageService->tuneShop) AS $tune)
+                {
+                    $field = GarageService::getTuneDbField($tune);
+                    $row['horsepower'] += $garageService->tuneShop[$tune][$row[$field]]['pk'];
+                    $row['topspeed'] += $garageService->tuneShop[$tune][$row[$field]]['ts'];
+                    $row['acceleration'] += $garageService->tuneShop[$tune][$row[$field]]['ac'];
+                    $row['control'] += $garageService->tuneShop[$tune][$row[$field]]['ct'];
+                    $row['breaking'] += $garageService->tuneShop[$tune][$row[$field]]['br'];
+                }
+                return $row;
+            }
+        }
+        return false;
+    }
+
+    public function updateUserCash($amount)
+    {
+        if(isset($_SESSION['UID']))
+        {
+            $this->con->setData(
+                "UPDATE `user` SET `cash` = `cash` + :amount WHERE `id` = :uid LIMIT 1",
+                array(':amount' => $amount, ':uid' => $_SESSION['UID'])
+            );
+        }
+    }
+}

--- a/public_html/src/Languages/lang.en.php
+++ b/public_html/src/Languages/lang.en.php
@@ -1404,6 +1404,7 @@ class GetLanguageContent
             'LEAVE' => $this->familyLangs()['LEAVE'],
             'QUIT' => $this->familyRaidLangs()['QUIT'],
             'RESULTS' => "Results",
+            'RACE_TYPE' => "Race type",
             'NO_VEHICLE_TO_RACE' => "You don't have a vehicle available in your garages.",
             'ALREADY_PART_OF_RACE' => "You're already part of a ".strtolower($str)."!",
             'NO_PART_OF_RACE' => "You're not part yet of a ".strtolower($str)."!",

--- a/public_html/src/Languages/lang.nl.php
+++ b/public_html/src/Languages/lang.nl.php
@@ -1404,6 +1404,7 @@ class GetLanguageContent
             'LEAVE' => $this->familyLangs()['LEAVE'],
             'QUIT' => $this->familyRaidLangs()['QUIT'],
             'RESULTS' => "Uitslag",
+            'RACE_TYPE' => "Race type",
             'NO_VEHICLE_TO_RACE' => "Je hebt geen voertuig beschikbaar in jouw garages.",
             'ALREADY_PART_OF_RACE' => "Je doet al mee aan een ".strtolower($str)."!",
             'NO_PART_OF_RACE' => "Je doet nog niet mee aan een ".strtolower($str)."!",

--- a/public_html/src/Views/game/Ajax/streetrace.twig
+++ b/public_html/src/Views/game/Ajax/streetrace.twig
@@ -1,0 +1,1 @@
+{% include "app/Resources/Views/macros/alerts.game.responses.twig" %}

--- a/public_html/src/Views/game/streetrace.twig
+++ b/public_html/src/Views/game/streetrace.twig
@@ -1,14 +1,40 @@
 {% extends "/app/Resources/Views/gamebase.twig" %}
 
 {% block content %}
-{#
 <div class="top">
-    Streetrace
+    {{ langs.TITLE }}
 </div>
 <div class="content-container">
     <div class="row">
-        Vroem
+        <p class="center">{{ langs.DESCRIPTION|raw }}</p>
     </div>
+    <div id="streetraceResponse"></div>
+    {% if vehicles is not empty %}
+        <form class="ajaxForm center" method="POST" action="{{ routing.getAjaxRouteByRouteName('play-streetrace') }}" data-response="#streetraceResponse">
+            <input type="hidden" name="security-token" value="{{ securityToken }}" />
+            <div class="row">
+                {{ langs.VEHICLE }}:
+                <select name="vehicle">
+                    {% for g in vehicles %}
+                        <option value="{{ g.getId }}">{{ g.getVehicle.getName }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="row">
+                {{ langs.RACE_TYPE }}:
+                <select name="type">
+                    {% for key, label in raceTypes %}
+                        <option value="{{ key }}">{{ label }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="row">
+                {{ langs.STAKE }}:&nbsp;<input type="number" name="stake" placeholder="{{ langs.STAKE }}" />
+                <input type="submit" name="streetrace" value="{{ langs.PLAY }}" />
+            </div>
+        </form>
+    {% else %}
+        <p class="center">{{ langs.NO_VEHICLE_TO_RACE }}</p>
+    {% endif %}
 </div>
-#}
 {% endblock content %}


### PR DESCRIPTION
## Summary
- add Streetrace service and DAO to simulate races and handle payouts
- expose streetrace through controllers, views and ajax route
- wire up navigation and translations for new streetrace feature

## Testing
- `php -l public_html/src/Data/StreetraceDAO.php`
- `php -l public_html/src/Business/StreetraceService.php`
- `php -l public_html/src/Controllers/Ajax/streetrace.play.php`
- `php -l public_html/src/Controllers/game/streetrace.php`
- `php -l public_html/app/config/routes/ajax.routes.php`
- `php -l public_html/src/Languages/lang.en.php`
- `php -l public_html/src/Languages/lang.nl.php`


------
https://chatgpt.com/codex/tasks/task_b_68a4b30158d88324a3fe1f73267640e5