### PR TITLE
Scope streetrace lobbies to player state

### DIFF
--- a/public_html/install/config/clean-database.sql
+++ b/public_html/install/config/clean-database.sql
@@ -1548,6 +1548,60 @@ CREATE TABLE `gym_competition`  (
 -- ----------------------------
 
 -- ----------------------------
+-- Table structure for streetrace_game
+-- ----------------------------
+DROP TABLE IF EXISTS `streetrace_game`;
+CREATE TABLE `streetrace_game`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `organizerID` int NOT NULL,
+  `stateID` smallint NOT NULL,
+  `type` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `stake` int NOT NULL DEFAULT 0,
+  `requiredPlayers` tinyint NOT NULL DEFAULT 2,
+  `status` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'open',
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `started` datetime NULL DEFAULT NULL,
+  `finished` datetime NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE,
+  KEY `organizerID` (`organizerID`),
+  KEY `stateID_idx` (`stateID`)
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci ROW_FORMAT = COMPACT;
+
+-- ----------------------------
+-- Records of streetrace_game
+-- ----------------------------
+
+-- ----------------------------
+-- Table structure for streetrace_participant
+-- ----------------------------
+DROP TABLE IF EXISTS `streetrace_participant`;
+CREATE TABLE `streetrace_participant`  (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `gameID` int NOT NULL,
+  `userID` int NOT NULL,
+  `vehicleGarageID` int NOT NULL,
+  `vehicleName` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `horsepower` int NOT NULL,
+  `topspeed` int NOT NULL,
+  `acceleration` int NOT NULL,
+  `control` int NOT NULL,
+  `breaking` int NOT NULL,
+  `score` int NOT NULL DEFAULT 0,
+  `position` tinyint NOT NULL DEFAULT 0,
+  `prize` int NOT NULL DEFAULT 0,
+  `joined` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`) USING BTREE,
+  UNIQUE INDEX `unique_game_user`(`gameID`, `userID`) USING BTREE,
+  INDEX `gameID_idx`(`gameID`) USING BTREE,
+  INDEX `userID_idx`(`userID`) USING BTREE,
+  CONSTRAINT `streetrace_participant_ibfk_1` FOREIGN KEY (`gameID`) REFERENCES `streetrace_game` (`id`) ON DELETE CASCADE
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci ROW_FORMAT = COMPACT;
+
+-- ----------------------------
+-- Records of streetrace_participant
+-- ----------------------------
+
+-- ----------------------------
 -- Table structure for helpsystem
 -- ----------------------------
 DROP TABLE IF EXISTS `helpsystem`;

--- a/public_html/src/Business/StreetraceService.php
+++ b/public_html/src/Business/StreetraceService.php
@@ -3,7 +3,10 @@
 namespace src\Business;
 
 use app\config\Routing;
+use src\Business\NotificationService;
 use src\Data\StreetraceDAO;
+use src\Entities\Streetrace;
+use src\Entities\StreetraceParticipant;
 
 class StreetraceService
 {
@@ -13,6 +16,12 @@ class StreetraceService
         'route66' => 'Route66',
         'drift' => 'Drift Race',
         'city' => 'City Race'
+    );
+    public $playerOptions = array(2, 3, 4);
+    private $payoutMultipliers = array(
+        2 => array(1 => 2),
+        3 => array(1 => 2, 2 => 1),
+        4 => array(1 => 3, 2 => 1)
     );
 
     public function __construct()
@@ -25,18 +34,49 @@ class StreetraceService
         $this->data = null;
     }
 
+    /**
+     * Fetch the streetrace overview scoped to the player's current state.
+     */
+    public function getOverview()
+    {
+        global $userData;
+
+        $stateId = (int)$userData->getStateID();
+
+        return array(
+            'openRaces' => $this->data->getOpenRaces($stateId),
+            'userRace' => $this->data->getUsersOpenRace(),
+            'lastResult' => $this->data->getUserLastResult()
+        );
+    }
+
     public function race($post)
+    {
+        $action = isset($post['action']) ? $post['action'] : 'organize';
+        switch($action)
+        {
+            case 'join':
+                return $this->joinRace($post);
+            case 'leave':
+                return $this->leaveRace($post);
+            default:
+                return $this->organizeRace($post);
+        }
+    }
+
+    private function organizeRace($post)
     {
         global $security;
         global $userData;
         global $language;
-        global $route;
         global $langs;
         $l = $language->streetraceLangs();
 
-        $stake = (int)$post['stake'];
+        $stake = isset($post['stake']) ? (int)$post['stake'] : 0;
         $type = isset($post['type']) ? $post['type'] : '';
-        $vehicleId = (int)$post['vehicle'];
+        $vehicleId = isset($post['vehicle']) ? (int)$post['vehicle'] : 0;
+        $requiredPlayers = isset($post['requiredPlayers']) ? (int)$post['requiredPlayers'] : 0;
+        $stateId = (int)$userData->getStateID();
 
         if($security->checkToken($post['security-token']) == false)
             $error = $langs['INVALID_SECURITY_TOKEN'];
@@ -46,58 +86,192 @@ class StreetraceService
             $error = $langs['CANT_DO_THAT_TRAVELLING'];
         if(!array_key_exists($type, $this->raceTypes))
             $error = $l['INVALID_RACE_TYPE'];
+        if(!in_array($requiredPlayers, $this->playerOptions))
+            $error = $l['INVALID_PLAYER_COUNT'];
         if($stake < 1)
             $error = $l['INVALID_STAKE'];
         if($userData->getCash() < $stake)
             $error = $langs['NOT_ENOUGH_MONEY_CASH'];
-        if(($vehicle = $this->data->getUserVehicle($vehicleId)) == false)
+        if(!isset($error) && $this->data->userHasOpenRace())
+            $error = $l['ALREADY_PART_OF_RACE'];
+        if(!isset($error) && ($vehicle = $this->data->getUserVehicle($vehicleId, $stateId)) == false)
             $error = $l['INVALID_VEHICLE'];
 
         if(isset($error))
             return Routing::errorMessage($error);
 
-        $playerScore = $this->calculateScore($vehicle, $type);
-        $scores = array(
-            $userData->getUsername() => $playerScore,
-            'Opponent 1' => $this->randomScore($type),
-            'Opponent 2' => $this->randomScore($type),
-            'Opponent 3' => $this->randomScore($type)
-        );
-        arsort($scores);
-        $position = array_search($userData->getUsername(), array_keys($scores)) + 1;
-
-        $profit = -$stake;
-        if($position === 1)
-            $profit += $stake * 3;
-        elseif($position === 2)
-            $profit += $stake;
-
-        $this->data->updateUserCash($profit);
-
-        if($position === 1)
+        try
         {
-            $msg = $route->replaceMessagePart(number_format($stake * 3, 0, '', ','), $l['RACE_SUCCESS_WON_FIRST'], '/{price}/');
-            return Routing::successMessage($msg);
+            $this->data->createRace($type, $stake, $requiredPlayers, $vehicle, $stateId);
+            return Routing::successMessage($l['ORGANIZE_RACE_SUCCESS']);
         }
-        elseif($position === 2)
+        catch(\Exception $e)
         {
-            return Routing::successMessage($l['RACE_SUCCESS_EVEN_SECOND']);
-        }
-        else
-        {
-            $msg = $route->replaceMessagePart($position, $l['RACE_SUCCESS_LOST_NTH'], '/{nth}/');
-            return Routing::errorMessage($msg);
+            return Routing::errorMessage($l['INVALID_RACE']);
         }
     }
 
-    private function calculateScore($vehicle, $type)
+    private function joinRace($post)
     {
         global $security;
-        $hp = $vehicle['horsepower'];
-        $ts = $vehicle['topspeed'];
-        $ac = $vehicle['acceleration'];
-        $ct = $vehicle['control'];
-        $br = $vehicle['breaking'];
+        global $userData;
+        global $language;
+        global $langs;
+        global $route;
+        $l = $language->streetraceLangs();
+
+        $raceId = isset($post['race']) ? (int)$post['race'] : 0;
+        $vehicleId = isset($post['vehicle']) ? (int)$post['vehicle'] : 0;
+        $stateId = (int)$userData->getStateID();
+
+        if($security->checkToken($post['security-token']) == false)
+            $error = $langs['INVALID_SECURITY_TOKEN'];
+        if($userData->getInPrison())
+            $error = $langs['CANT_DO_THAT_IN_PRISON'];
+        if($userData->getTraveling())
+            $error = $langs['CANT_DO_THAT_TRAVELLING'];
+
+        $race = $this->data->getRaceById($raceId);
+        if(!$race instanceof Streetrace || $race->getStatus() !== 'open')
+            $error = $l['INVALID_RACE'];
+        elseif($race->getParticipantCount() >= $race->getRequiredPlayers())
+            $error = $l['RACE_ALREADY_FULL'];
+        elseif($race->getStateID() !== $stateId)
+            $error = $l['NOT_IN_SAME_STATE'];
+
+        $openRaceId = $this->data->userHasOpenRace();
+        if(!isset($error) && $openRaceId && $openRaceId != $raceId)
+            $error = $l['ALREADY_PART_OF_RACE'];
+
+        if(!isset($error) && $this->data->getUserParticipant($raceId))
+            $error = $l['ALREADY_PART_OF_RACE'];
+
+        if(!isset($error) && ($vehicle = $this->data->getUserVehicle($vehicleId, $stateId)) == false)
+            $error = $l['INVALID_VEHICLE'];
+
+        if(!isset($error) && $userData->getCash() < $race->getStake())
+            $error = $langs['NOT_ENOUGH_MONEY_CASH'];
+
+        if(isset($error))
+            return Routing::errorMessage($error);
+
+        try
+        {
+            $this->data->addParticipant($raceId, $vehicle, $race->getStake());
+            $race = $this->data->getRaceById($raceId);
+            if($race instanceof Streetrace && $race->getParticipantCount() >= $race->getRequiredPlayers())
+            {
+                $results = $this->prepareRaceResults($race);
+                $this->data->completeRace($raceId, $results);
+                $this->notifyRaceResults($race, $results);
+                foreach($results AS $result)
+                {
+                    if($result['userId'] == $_SESSION['UID'])
+                    {
+                        return $this->formatResultMessage($result['position'], $result['prize'], $race->getStake(), $route, $l);
+                    }
+                }
+            }
+            return Routing::successMessage($l['JOIN_RACE_SUCCESS']);
+        }
+        catch(\Exception $e)
+        {
+            return Routing::errorMessage($l['INVALID_RACE']);
+        }
+    }
+
+    private function leaveRace($post)
+    {
+        global $security;
+        global $language;
+        global $langs;
+        $l = $language->streetraceLangs();
+
+        $raceId = isset($post['race']) ? (int)$post['race'] : 0;
+
+        if($security->checkToken($post['security-token']) == false)
+            $error = $langs['INVALID_SECURITY_TOKEN'];
+
+        $race = $this->data->getRaceById($raceId);
+        if(!$race instanceof Streetrace || $race->getStatus() !== 'open')
+            $error = $l['INVALID_RACE'];
+
+        $participant = null;
+        if(!isset($error))
+            $participant = $this->data->getUserParticipant($raceId);
+        if(!isset($error) && !$participant)
+            $error = $l['NO_PART_OF_RACE'];
+
+        if(isset($error))
+            return Routing::errorMessage($error);
+
+        try
+        {
+            $this->data->removeParticipant($raceId, $race->getStake());
+            $this->data->cancelRaceIfEmpty($raceId);
+            return Routing::successMessage($l['LEAVE_RACE_SUCCESS']);
+        }
+        catch(\Exception $e)
+        {
+            return Routing::errorMessage($l['INVALID_RACE']);
+        }
+    }
+
+    private function prepareRaceResults(Streetrace $race)
+    {
+        global $security;
+        $participants = $race->getParticipants();
+        $results = array();
+        $scored = array();
+        foreach($participants AS $participant)
+        {
+            if(!$participant instanceof StreetraceParticipant)
+                continue;
+
+            $score = $this->calculateParticipantScore($participant, $race->getType());
+            $scored[] = array(
+                'participant' => $participant,
+                'score' => $score,
+                'tiebreaker' => $security->randInt(0, 1000000)
+            );
+        }
+
+        usort($scored, function($a, $b) {
+            if($a['score'] === $b['score'])
+                return $b['tiebreaker'] <=> $a['tiebreaker'];
+            return $b['score'] <=> $a['score'];
+        });
+
+        $multipliers = $this->getPayoutMultipliers($race->getRequiredPlayers());
+        $position = 1;
+        foreach($scored AS $row)
+        {
+            /** @var StreetraceParticipant $participant */
+            $participant = $row['participant'];
+            $prize = isset($multipliers[$position]) ? $race->getStake() * $multipliers[$position] : 0;
+            $participant->setScore($row['score']);
+            $participant->setPosition($position);
+            $participant->setPrize($prize);
+            $results[] = array(
+                'participantId' => $participant->getId(),
+                'userId' => $participant->getUserID(),
+                'score' => $row['score'],
+                'position' => $position,
+                'prize' => $prize,
+                'participant' => $participant
+            );
+            $position++;
+        }
+        return $results;
+    }
+
+    private function calculateParticipantScore(StreetraceParticipant $participant, $type)
+    {
+        $hp = $participant->getHorsepower();
+        $ts = $participant->getTopspeed();
+        $ac = $participant->getAcceleration();
+        $ct = $participant->getControl();
+        $br = $participant->getBreaking();
 
         switch($type)
         {
@@ -115,20 +289,88 @@ class StreetraceService
                 $score = $ac * 2 + $ct + $br;
                 break;
         }
-        $score += $security->randInt(0, 100);
-        return $score;
+        return (int)$score;
     }
 
-    private function randomScore($type)
+    private function getPayoutMultipliers($requiredPlayers)
     {
-        global $security;
-        $vehicle = array(
-            'horsepower' => $security->randInt(200, 800),
-            'topspeed' => $security->randInt(200, 350),
-            'acceleration' => $security->randInt(20, 80),
-            'control' => $security->randInt(10, 100),
-            'breaking' => $security->randInt(10, 100)
-        );
-        return $this->calculateScore($vehicle, $type);
+        if(isset($this->payoutMultipliers[$requiredPlayers]))
+            return $this->payoutMultipliers[$requiredPlayers];
+        return array(1 => $requiredPlayers);
+    }
+
+    private function notifyRaceResults(Streetrace $race, array $results)
+    {
+        if(empty($results))
+            return;
+
+        global $language;
+        $l = $language->streetraceLangs();
+        $raceLabel = isset($this->raceTypes[$race->getType()]) ? $this->raceTypes[$race->getType()] : ucfirst($race->getType());
+        $raceName = $raceLabel . ' ' . $l['TITLE'];
+
+        $notification = new NotificationService();
+
+        foreach($results AS $result)
+        {
+            if(!isset($result['participant']) || !$result['participant'] instanceof StreetraceParticipant)
+                continue;
+
+            $messageKey = $result['prize'] > 0 ? 'STREETRACE_RESULT_PRIZE' : 'STREETRACE_RESULT_LOSS';
+
+            $params = 'race=' . $raceName;
+            $params .= '&placeOrdinal=' . $this->formatEnglishPlacement($result['position']);
+            $params .= '&placeNl=' . $this->formatDutchPlacement($result['position']);
+            $params .= '&prize=' . number_format($result['prize'], 0, '', ',');
+
+            $notification->sendNotification($result['userId'], $messageKey, $params);
+        }
+    }
+
+    private function formatEnglishPlacement($position)
+    {
+        $suffix = 'th';
+        if(($position % 100) < 11 || ($position % 100) > 13)
+        {
+            switch($position % 10)
+            {
+                case 1:
+                    $suffix = 'st';
+                    break;
+                case 2:
+                    $suffix = 'nd';
+                    break;
+                case 3:
+                    $suffix = 'rd';
+                    break;
+            }
+        }
+        return $position . $suffix . ' place';
+    }
+
+    private function formatDutchPlacement($position)
+    {
+        return $position . 'e plaats';
+    }
+
+    private function formatResultMessage($position, $prize, $stake, $route, $l)
+    {
+        if($position === 1)
+        {
+            $msg = $route->replaceMessagePart(number_format($prize, 0, '', ','), $l['RACE_SUCCESS_WON_FIRST'], '/{price}/');
+            return Routing::successMessage($msg);
+        }
+        if($prize === $stake)
+            return Routing::successMessage($l['RACE_SUCCESS_EVEN_SECOND']);
+        if($prize > 0)
+        {
+            $msg = $route->replaceMessageParts(array(
+                array('part' => $position, 'message' => $l['RACE_SUCCESS_WON_NTH'], 'pattern' => '/{nth}/'),
+                array('part' => number_format($prize, 0, '', ','), 'message' => false, 'pattern' => '/{price}/')
+            ));
+            return Routing::successMessage($msg);
+        }
+        $msg = $route->replaceMessagePart($position, $l['RACE_SUCCESS_LOST_NTH'], '/{nth}/');
+        return Routing::errorMessage($msg);
     }
 }

--- a/public_html/src/Controllers/Ajax/streetrace.play.php
+++ b/public_html/src/Controllers/Ajax/streetrace.play.php
@@ -4,7 +4,26 @@ use src\Business\StreetraceService;
 
 require_once __DIR__ . '/.inc.head.ajax.php';
 
-if(isset($_POST['security-token']) && isset($_POST['vehicle']) && isset($_POST['stake']) && isset($_POST['type']))
+$action = isset($_POST['action']) ? $_POST['action'] : 'organize';
+$required = array('security-token');
+if($action === 'join')
+    $required = array_merge($required, array('race', 'vehicle'));
+elseif($action === 'leave')
+    $required = array_merge($required, array('race'));
+else
+    $required = array_merge($required, array('vehicle', 'stake', 'type', 'requiredPlayers'));
+
+$missing = false;
+foreach($required AS $field)
+{
+    if(!isset($_POST[$field]))
+    {
+        $missing = true;
+        break;
+    }
+}
+
+if($missing === false)
 {
     $streetrace = new StreetraceService();
     $response = $streetrace->race($_POST);

--- a/public_html/src/Controllers/game/streetrace.php
+++ b/public_html/src/Controllers/game/streetrace.php
@@ -8,11 +8,16 @@ require_once __DIR__ . '/.inc.head.php';
 $garage = new GarageService();
 $vehicles = $garage->getAllVehiclesInGarageByState($userData->getStateID());
 $streetrace = new StreetraceService();
+$overview = $streetrace->getOverview();
 
 require_once __DIR__ . '/.inc.foot.php';
 
 $twigVars['langs'] = array_merge($twigVars['langs'], $language->streetraceLangs());
 $twigVars['vehicles'] = $vehicles;
 $twigVars['raceTypes'] = $streetrace->raceTypes;
+$twigVars['playerOptions'] = $streetrace->playerOptions;
+$twigVars['openRaces'] = $overview['openRaces'];
+$twigVars['userRace'] = $overview['userRace'];
+$twigVars['lastResult'] = $overview['lastResult'];
 
 print_r($twig->render('/src/Views/game/streetrace.twig', $twigVars));

--- a/public_html/src/Data/StreetraceDAO.php
+++ b/public_html/src/Data/StreetraceDAO.php
@@ -2,8 +2,11 @@
 
 namespace src\Data;
 
+use PDOException;
 use src\Business\GarageService;
 use src\Data\config\DBConfig;
+use src\Entities\Streetrace;
+use src\Entities\StreetraceParticipant;
 
 class StreetraceDAO extends DBConfig
 {
@@ -22,12 +25,12 @@ class StreetraceDAO extends DBConfig
         $this->dbh = null;
     }
 
-    public function getUserVehicle($garageId)
+    public function getUserVehicle($garageId, $stateId)
     {
         if(isset($_SESSION['UID']))
         {
-            $statement = $this->dbh->prepare("SELECT g.`id`, v.`horsepower`, v.`topspeed`, v.`acceleration`, v.`control`, v.`breaking`, g.`tires`, g.`engine`, g.`exhaust`, g.`shockAbsorbers` FROM `garage` AS g LEFT JOIN `user_garage` AS ug ON (g.`userGarageID` = ug.`id`) LEFT JOIN `vehicle` AS v ON (g.`vehicleID` = v.`id`) WHERE g.`id` = :gid AND ug.`userID` = :uid AND g.`active`='1' AND g.`deleted`='0' AND v.`active`='1' AND v.`deleted`='0'");
-            $statement->execute(array(':gid' => $garageId, ':uid' => $_SESSION['UID']));
+            $statement = $this->dbh->prepare("SELECT g.`id`, v.`name` AS `vehicleName`, v.`horsepower`, v.`topspeed`, v.`acceleration`, v.`control`, v.`breaking`, g.`tires`, g.`engine`, g.`exhaust`, g.`shockAbsorbers` FROM `garage` AS g LEFT JOIN `user_garage` AS ug ON (g.`userGarageID` = ug.`id`) LEFT JOIN `vehicle` AS v ON (g.`vehicleID` = v.`id`) WHERE g.`id` = :gid AND ug.`userID` = :uid AND ug.`stateID` = :stateID AND g.`active`='1' AND g.`deleted`='0' AND v.`active`='1' AND v.`deleted`='0'");
+            $statement->execute(array(':gid' => $garageId, ':uid' => $_SESSION['UID'], ':stateID' => $stateId));
             $row = $statement->fetch();
             if(isset($row['id']))
             {
@@ -47,14 +50,336 @@ class StreetraceDAO extends DBConfig
         return false;
     }
 
-    public function updateUserCash($amount)
+    public function userHasOpenRace()
     {
         if(isset($_SESSION['UID']))
         {
-            $this->con->setData(
-                "UPDATE `user` SET `cash` = `cash` + :amount WHERE `id` = :uid LIMIT 1",
-                array(':amount' => $amount, ':uid' => $_SESSION['UID'])
+            $row = $this->con->getDataSR(
+                "SELECT g.`id` FROM `streetrace_game` AS g LEFT JOIN `streetrace_participant` AS p ON (p.`gameID` = g.`id`) WHERE p.`userID` = :uid AND g.`status`='open' LIMIT 1",
+                array(':uid' => $_SESSION['UID'])
             );
+            if(isset($row['id']))
+                return $row['id'];
         }
+        return false;
+    }
+
+    public function createRace($type, $stake, $requiredPlayers, array $vehicle, $stateId)
+    {
+        if(!isset($_SESSION['UID']))
+            return false;
+
+        try
+        {
+            $this->dbh->beginTransaction();
+
+            $statement = $this->dbh->prepare(
+                "INSERT INTO `streetrace_game` (`organizerID`, `stateID`, `type`, `stake`, `requiredPlayers`, `status`, `created`) VALUES (:uid, :stateID, :type, :stake, :requiredPlayers, 'open', NOW())"
+            );
+            $statement->execute(array(
+                ':uid' => $_SESSION['UID'],
+                ':stateID' => $stateId,
+                ':type' => $type,
+                ':stake' => $stake,
+                ':requiredPlayers' => $requiredPlayers
+            ));
+            $raceId = (int)$this->dbh->lastInsertId();
+
+            $this->insertParticipant($raceId, $vehicle, $stake);
+
+            $this->dbh->commit();
+
+            return $raceId;
+        }
+        catch(PDOException $e)
+        {
+            $this->dbh->rollBack();
+            throw $e;
+        }
+    }
+
+    public function addParticipant($raceId, array $vehicle, $stake)
+    {
+        if(!isset($_SESSION['UID']))
+            return false;
+
+        try
+        {
+            $this->dbh->beginTransaction();
+
+            $this->insertParticipant($raceId, $vehicle, $stake);
+
+            $this->dbh->commit();
+            return true;
+        }
+        catch(PDOException $e)
+        {
+            $this->dbh->rollBack();
+            throw $e;
+        }
+    }
+
+    private function insertParticipant($raceId, array $vehicle, $stake)
+    {
+        $statement = $this->dbh->prepare(
+            "INSERT INTO `streetrace_participant` (`gameID`, `userID`, `vehicleGarageID`, `vehicleName`, `horsepower`, `topspeed`, `acceleration`, `control`, `breaking`, `joined`) VALUES (:raceID, :uid, :vehicleID, :vehicleName, :horsepower, :topspeed, :acceleration, :control, :breaking, NOW())"
+        );
+        $statement->execute(array(
+            ':raceID' => $raceId,
+            ':uid' => $_SESSION['UID'],
+            ':vehicleID' => $vehicle['id'],
+            ':vehicleName' => $vehicle['vehicleName'],
+            ':horsepower' => $vehicle['horsepower'],
+            ':topspeed' => $vehicle['topspeed'],
+            ':acceleration' => $vehicle['acceleration'],
+            ':control' => $vehicle['control'],
+            ':breaking' => $vehicle['breaking']
+        ));
+
+        $update = $this->dbh->prepare("UPDATE `user` SET `cash` = `cash` - :stake WHERE `id` = :uid LIMIT 1");
+        $update->execute(array(':stake' => $stake, ':uid' => $_SESSION['UID']));
+    }
+
+    public function removeParticipant($raceId, $stake)
+    {
+        if(!isset($_SESSION['UID']))
+            return false;
+
+        try
+        {
+            $this->dbh->beginTransaction();
+
+            $delete = $this->dbh->prepare("DELETE FROM `streetrace_participant` WHERE `gameID` = :raceID AND `userID` = :uid LIMIT 1");
+            $delete->execute(array(':raceID' => $raceId, ':uid' => $_SESSION['UID']));
+
+            $refund = $this->dbh->prepare("UPDATE `user` SET `cash` = `cash` + :stake WHERE `id` = :uid LIMIT 1");
+            $refund->execute(array(':stake' => $stake, ':uid' => $_SESSION['UID']));
+
+            $this->dbh->commit();
+            return true;
+        }
+        catch(PDOException $e)
+        {
+            $this->dbh->rollBack();
+            throw $e;
+        }
+    }
+
+    public function cancelRaceIfEmpty($raceId)
+    {
+        $count = $this->countParticipants($raceId);
+        if($count === 0)
+        {
+            $statement = $this->dbh->prepare("UPDATE `streetrace_game` SET `status`='cancelled', `finished`=NOW() WHERE `id` = :raceID LIMIT 1");
+            $statement->execute(array(':raceID' => $raceId));
+        }
+    }
+
+    public function getOpenRaces($stateId)
+    {
+        if(isset($_SESSION['UID']))
+        {
+            $rows = $this->con->getData(
+                "SELECT g.`id`, g.`type`, g.`stake`, g.`requiredPlayers`, g.`created`, g.`organizerID`, g.`stateID`, u.`username` AS `organizerName`, s.`name` AS `stateName`, (SELECT COUNT(*) FROM `streetrace_participant` AS sp WHERE sp.`gameID` = g.`id`) AS `participants` FROM `streetrace_game` AS g LEFT JOIN `user` AS u ON (g.`organizerID` = u.`id`) LEFT JOIN `state` AS s ON (g.`stateID` = s.`id`) WHERE g.`status`='open' AND g.`stateID` = :stateID ORDER BY g.`created` ASC",
+                array(':stateID' => $stateId)
+            );
+            $list = array();
+            foreach($rows AS $row)
+            {
+                $race = new Streetrace();
+                $race->setId($row['id']);
+                $race->setType($row['type']);
+                $race->setStake($row['stake']);
+                $race->setRequiredPlayers($row['requiredPlayers']);
+                $race->setCreated($row['created']);
+                $race->setOrganizerID($row['organizerID']);
+                $race->setOrganizerName($row['organizerName']);
+                $race->setStateID($row['stateID']);
+                $race->setStateName($row['stateName']);
+                $race->setParticipantCount((int)$row['participants']);
+                $list[] = $race;
+            }
+            return $list;
+        }
+        return array();
+    }
+
+    public function getUsersOpenRace()
+    {
+        if(isset($_SESSION['UID']))
+        {
+            $row = $this->con->getDataSR(
+                "SELECT g.`id`, g.`type`, g.`stake`, g.`requiredPlayers`, g.`created`, g.`organizerID`, g.`stateID`, u.`username` AS `organizerName`, s.`name` AS `stateName` FROM `streetrace_game` AS g LEFT JOIN `streetrace_participant` AS sp ON (sp.`gameID` = g.`id`) LEFT JOIN `user` AS u ON (g.`organizerID` = u.`id`) LEFT JOIN `state` AS s ON (g.`stateID` = s.`id`) WHERE sp.`userID` = :uid AND g.`status`='open' LIMIT 1",
+                array(':uid' => $_SESSION['UID'])
+            );
+
+            if(isset($row['id']))
+            {
+                $race = new Streetrace();
+                $race->setId($row['id']);
+                $race->setType($row['type']);
+                $race->setStake($row['stake']);
+                $race->setRequiredPlayers($row['requiredPlayers']);
+                $race->setCreated($row['created']);
+                $race->setOrganizerID($row['organizerID']);
+                $race->setOrganizerName($row['organizerName']);
+                $race->setStateID($row['stateID']);
+                $race->setStateName($row['stateName']);
+                $participants = $this->getRaceParticipants($row['id']);
+                $race->setParticipants($participants);
+                $race->setParticipantCount(count($participants));
+                return $race;
+            }
+        }
+        return false;
+    }
+
+    public function getRaceById($raceId)
+    {
+        $row = $this->con->getDataSR(
+            "SELECT g.`id`, g.`type`, g.`stake`, g.`requiredPlayers`, g.`status`, g.`created`, g.`started`, g.`finished`, g.`organizerID`, g.`stateID`, u.`username` AS `organizerName`, s.`name` AS `stateName` FROM `streetrace_game` AS g LEFT JOIN `user` AS u ON (g.`organizerID` = u.`id`) LEFT JOIN `state` AS s ON (g.`stateID` = s.`id`) WHERE g.`id` = :raceID",
+            array(':raceID' => $raceId)
+        );
+
+        if(isset($row['id']))
+        {
+            $race = new Streetrace();
+            $race->setId($row['id']);
+            $race->setType($row['type']);
+            $race->setStake($row['stake']);
+            $race->setRequiredPlayers($row['requiredPlayers']);
+            $race->setStatus($row['status']);
+            $race->setCreated($row['created']);
+            $race->setStarted($row['started']);
+            $race->setFinished($row['finished']);
+            $race->setOrganizerID($row['organizerID']);
+            $race->setOrganizerName($row['organizerName']);
+            $race->setStateID($row['stateID']);
+            $race->setStateName($row['stateName']);
+            $participants = $this->getRaceParticipants($row['id'], true);
+            $race->setParticipants($participants);
+            $race->setParticipantCount(count($participants));
+            return $race;
+        }
+        return false;
+    }
+
+    public function getRaceParticipants($raceId, $includeResults = false)
+    {
+        $order = $includeResults ? "ORDER BY sp.`position` ASC, sp.`joined` ASC" : "ORDER BY sp.`joined` ASC";
+        $statement = $this->dbh->prepare(
+            "SELECT sp.`id`, sp.`userID`, u.`username`, sp.`vehicleName`, sp.`vehicleGarageID`, sp.`horsepower`, sp.`topspeed`, sp.`acceleration`, sp.`control`, sp.`breaking`, sp.`score`, sp.`position`, sp.`prize`, sp.`joined` FROM `streetrace_participant` AS sp LEFT JOIN `user` AS u ON (sp.`userID` = u.`id`) WHERE sp.`gameID` = :raceID " . $order
+        );
+        $statement->execute(array(':raceID' => $raceId));
+
+        $participants = array();
+        foreach($statement AS $row)
+        {
+            $participant = new StreetraceParticipant();
+            $participant->setId($row['id']);
+            $participant->setGameID($raceId);
+            $participant->setUserID($row['userID']);
+            $participant->setUsername($row['username']);
+            $participant->setVehicleGarageID($row['vehicleGarageID']);
+            $participant->setVehicleName($row['vehicleName']);
+            $participant->setHorsepower($row['horsepower']);
+            $participant->setTopspeed($row['topspeed']);
+            $participant->setAcceleration($row['acceleration']);
+            $participant->setControl($row['control']);
+            $participant->setBreaking($row['breaking']);
+            $participant->setScore($row['score']);
+            $participant->setPosition($row['position']);
+            $participant->setPrize($row['prize']);
+            $participant->setJoined($row['joined']);
+            $participants[] = $participant;
+        }
+        return $participants;
+    }
+
+    public function countParticipants($raceId)
+    {
+        $row = $this->con->getDataSR(
+            "SELECT COUNT(*) AS `total` FROM `streetrace_participant` WHERE `gameID` = :raceID",
+            array(':raceID' => $raceId)
+        );
+        return isset($row['total']) ? (int)$row['total'] : 0;
+    }
+
+    public function getUserParticipant($raceId)
+    {
+        if(isset($_SESSION['UID']))
+        {
+            $statement = $this->dbh->prepare("SELECT `id`, `userID`, `vehicleName`, `horsepower`, `topspeed`, `acceleration`, `control`, `breaking`, `score`, `position`, `prize` FROM `streetrace_participant` WHERE `gameID` = :raceID AND `userID` = :uid LIMIT 1");
+            $statement->execute(array(':raceID' => $raceId, ':uid' => $_SESSION['UID']));
+            $row = $statement->fetch();
+            if(isset($row['id']))
+            {
+                $participant = new StreetraceParticipant();
+                $participant->setId($row['id']);
+                $participant->setGameID($raceId);
+                $participant->setUserID($row['userID']);
+                $participant->setVehicleName($row['vehicleName']);
+                $participant->setHorsepower($row['horsepower']);
+                $participant->setTopspeed($row['topspeed']);
+                $participant->setAcceleration($row['acceleration']);
+                $participant->setControl($row['control']);
+                $participant->setBreaking($row['breaking']);
+                $participant->setScore($row['score']);
+                $participant->setPosition($row['position']);
+                $participant->setPrize($row['prize']);
+                return $participant;
+            }
+        }
+        return false;
+    }
+
+    public function completeRace($raceId, array $results)
+    {
+        try
+        {
+            $this->dbh->beginTransaction();
+
+            $updateParticipant = $this->dbh->prepare("UPDATE `streetrace_participant` SET `score` = :score, `position` = :position, `prize` = :prize WHERE `id` = :id LIMIT 1");
+            $updateUser = $this->dbh->prepare("UPDATE `user` SET `cash` = `cash` + :prize WHERE `id` = :uid LIMIT 1");
+            foreach($results AS $result)
+            {
+                $updateParticipant->execute(array(
+                    ':score' => $result['score'],
+                    ':position' => $result['position'],
+                    ':prize' => $result['prize'],
+                    ':id' => $result['participantId']
+                ));
+
+                if($result['prize'] > 0)
+                {
+                    $updateUser->execute(array(':prize' => $result['prize'], ':uid' => $result['userId']));
+                }
+            }
+
+            $statement = $this->dbh->prepare("UPDATE `streetrace_game` SET `status`='finished', `started` = COALESCE(`started`, NOW()), `finished` = NOW() WHERE `id` = :raceID LIMIT 1");
+            $statement->execute(array(':raceID' => $raceId));
+
+            $this->dbh->commit();
+            return true;
+        }
+        catch(PDOException $e)
+        {
+            $this->dbh->rollBack();
+            throw $e;
+        }
+    }
+
+    public function getUserLastResult()
+    {
+        if(isset($_SESSION['UID']))
+        {
+            $row = $this->con->getDataSR(
+                "SELECT g.`id` FROM `streetrace_game` AS g LEFT JOIN `streetrace_participant` AS sp ON (sp.`gameID` = g.`id`) WHERE sp.`userID` = :uid AND g.`status`='finished' ORDER BY g.`finished` DESC LIMIT 1",
+                array(':uid' => $_SESSION['UID'])
+            );
+            if(isset($row['id']))
+                return $this->getRaceById($row['id']);
+        }
+        return false;
     }
 }

--- a/public_html/src/Entities/Streetrace.php
+++ b/public_html/src/Entities/Streetrace.php
@@ -1,0 +1,161 @@
+<?PHP
+
+namespace src\Entities;
+
+class Streetrace
+{
+    private $id;
+    private $organizerID;
+    private $organizerName;
+    private $type;
+    private $stake;
+    private $requiredPlayers;
+    private $status;
+    private $created;
+    private $started;
+    private $finished;
+    private $stateID;
+    private $stateName;
+    private $participantCount = 0;
+    private $participants = array();
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getOrganizerID()
+    {
+        return $this->organizerID;
+    }
+
+    public function setOrganizerID($organizerID)
+    {
+        $this->organizerID = $organizerID;
+    }
+
+    public function getOrganizerName()
+    {
+        return $this->organizerName;
+    }
+
+    public function setOrganizerName($organizerName)
+    {
+        $this->organizerName = $organizerName;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    public function getStake()
+    {
+        return $this->stake;
+    }
+
+    public function setStake($stake)
+    {
+        $this->stake = $stake;
+    }
+
+    public function getRequiredPlayers()
+    {
+        return $this->requiredPlayers;
+    }
+
+    public function setRequiredPlayers($requiredPlayers)
+    {
+        $this->requiredPlayers = $requiredPlayers;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    public function getCreated()
+    {
+        return $this->created;
+    }
+
+    public function setCreated($created)
+    {
+        $this->created = $created;
+    }
+
+    public function getStarted()
+    {
+        return $this->started;
+    }
+
+    public function setStarted($started)
+    {
+        $this->started = $started;
+    }
+
+    public function getFinished()
+    {
+        return $this->finished;
+    }
+
+    public function setFinished($finished)
+    {
+        $this->finished = $finished;
+    }
+
+    public function getStateID()
+    {
+        return $this->stateID;
+    }
+
+    public function setStateID($stateID)
+    {
+        $this->stateID = is_null($stateID) ? null : (int)$stateID;
+    }
+
+    public function getStateName()
+    {
+        return $this->stateName;
+    }
+
+    public function setStateName($stateName)
+    {
+        $this->stateName = $stateName;
+    }
+
+    public function getParticipantCount()
+    {
+        return $this->participantCount;
+    }
+
+    public function setParticipantCount($participantCount)
+    {
+        $this->participantCount = $participantCount;
+    }
+
+    public function getParticipants()
+    {
+        return $this->participants;
+    }
+
+    public function setParticipants($participants)
+    {
+        $this->participants = $participants;
+    }
+}

--- a/public_html/src/Entities/StreetraceParticipant.php
+++ b/public_html/src/Entities/StreetraceParticipant.php
@@ -1,0 +1,172 @@
+<?PHP
+
+namespace src\Entities;
+
+class StreetraceParticipant
+{
+    private $id;
+    private $gameID;
+    private $userID;
+    private $username;
+    private $vehicleGarageID;
+    private $vehicleName;
+    private $horsepower;
+    private $topspeed;
+    private $acceleration;
+    private $control;
+    private $breaking;
+    private $score = 0;
+    private $position = 0;
+    private $prize = 0;
+    private $joined;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getGameID()
+    {
+        return $this->gameID;
+    }
+
+    public function setGameID($gameID)
+    {
+        $this->gameID = $gameID;
+    }
+
+    public function getUserID()
+    {
+        return $this->userID;
+    }
+
+    public function setUserID($userID)
+    {
+        $this->userID = $userID;
+    }
+
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    public function getVehicleGarageID()
+    {
+        return $this->vehicleGarageID;
+    }
+
+    public function setVehicleGarageID($vehicleGarageID)
+    {
+        $this->vehicleGarageID = $vehicleGarageID;
+    }
+
+    public function getVehicleName()
+    {
+        return $this->vehicleName;
+    }
+
+    public function setVehicleName($vehicleName)
+    {
+        $this->vehicleName = $vehicleName;
+    }
+
+    public function getHorsepower()
+    {
+        return $this->horsepower;
+    }
+
+    public function setHorsepower($horsepower)
+    {
+        $this->horsepower = $horsepower;
+    }
+
+    public function getTopspeed()
+    {
+        return $this->topspeed;
+    }
+
+    public function setTopspeed($topspeed)
+    {
+        $this->topspeed = $topspeed;
+    }
+
+    public function getAcceleration()
+    {
+        return $this->acceleration;
+    }
+
+    public function setAcceleration($acceleration)
+    {
+        $this->acceleration = $acceleration;
+    }
+
+    public function getControl()
+    {
+        return $this->control;
+    }
+
+    public function setControl($control)
+    {
+        $this->control = $control;
+    }
+
+    public function getBreaking()
+    {
+        return $this->breaking;
+    }
+
+    public function setBreaking($breaking)
+    {
+        $this->breaking = $breaking;
+    }
+
+    public function getScore()
+    {
+        return $this->score;
+    }
+
+    public function setScore($score)
+    {
+        $this->score = $score;
+    }
+
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    public function setPosition($position)
+    {
+        $this->position = $position;
+    }
+
+    public function getPrize()
+    {
+        return $this->prize;
+    }
+
+    public function setPrize($prize)
+    {
+        $this->prize = $prize;
+    }
+
+    public function getJoined()
+    {
+        return $this->joined;
+    }
+
+    public function setJoined($joined)
+    {
+        $this->joined = $joined;
+    }
+}

--- a/public_html/src/Languages/Notifications.php
+++ b/public_html/src/Languages/Notifications.php
@@ -45,7 +45,11 @@ class Notifications
             "FIFTY_GAME_CHALLENGE_WIN_CASH" => "You've beat {user} in a 50/50 game and doubled your stake of $&#8203;{stake} {type}.",
             "FIFTY_GAME_CHALLENGE_LOSE" => "{user} beat you in a 50/50 game and you lost your stake of {stake} {type}.",
             "FIFTY_GAME_CHALLENGE_LOSE_CASH" => "{user} beat you in a 50/50 game and you lost your stake of $&#8203;{stake} {type}.",
-            
+
+            /* STREETRACE */
+            "STREETRACE_RESULT_PRIZE" => "You've finished in {placeOrdinal} in the {race} streetrace and received $&#8203;{prize}.",
+            "STREETRACE_RESULT_LOSS" => "You've finished in {placeOrdinal} in the {race} streetrace and lost your stake.",
+
             /* LOTTERY */
             "USER_WON_WEEKLY_LOTTERY" => "You won at no. {place} and received $&#8203;{prize} with the weekly superpot.",
             "USER_WON_DAILY_LOTTERY" => "You won at no. {place} and received $&#8203;{prize} with the daily lottery.",
@@ -145,7 +149,11 @@ class Notifications
             "FIFTY_GAME_CHALLENGE_WIN_CASH" => "Je hebt {user} verslagen in een 50/50 spel en je inzet van $&#8203;{stake} {type} verdubbeld.",
             "FIFTY_GAME_CHALLENGE_LOSE" => "Je hebt verloren van {user} in een 50/50 spel en je inzet van {stake} {type} verloren.",
             "FIFTY_GAME_CHALLENGE_LOSE_CASH" => "Je hebt verloren van {user} in een 50/50 spel en je inzet van $&#8203;{stake} {type} verloren.",
-            
+
+            /* STREETRACE */
+            "STREETRACE_RESULT_PRIZE" => "Je eindigde op de {placeNl} in de {race} streetrace en ontving $&#8203;{prize}.",
+            "STREETRACE_RESULT_LOSS" => "Je eindigde op de {placeNl} in de {race} streetrace en verloor je inzet.",
+
             /* LOTTERY */
             "USER_WON_WEEKLY_LOTTERY" => "Je hebt de {place}e prijs gewonnen t.w.v. $&#8203;{prize} met de wekelijkse superpot.",
             "USER_WON_DAILY_LOTTERY" => "Je hebt de {place}e prijs gewonnen t.w.v. $&#8203;{prize} met de dagelijkse loterij.",

--- a/public_html/src/Languages/lang.en.php
+++ b/public_html/src/Languages/lang.en.php
@@ -1397,7 +1397,7 @@ class GetLanguageContent
         $famCrimeLangs = $this->familyCrimeLangs();
         $langs = array(
             'TITLE' => ucfirst($str),
-            'DESCRIPTION' => "Er zijn 4 soorten ".strtolower($str)."s: Highway, Route66, Drift Race en City Race.<br />Voor elk soort race moet je auto goed zijn op andere punten.<br /><br />De winnaar van de ".strtolower($str)." krijgt 3 keer de inzet, en de nummer 2 krijgt zijn inzet terug.<br />De nummer 3 en 4 verliezen hun geld.",
+            'DESCRIPTION' => "Streetraces can now be organised for multiple players. Pick a race type, choose the amount of players required and set your stake.<br />Once the lobby is full the race will start automatically. The vehicle with the best combined stats for the selected race type wins the race. When there is a draw the winner is selected at random.",
             'ORGANIZE' => $famCrimeLangs['ORGANIZE'],
             'PARTICIPANTS' => $famCrimeLangs['PARTICIPANTS'],
             'JOIN' => $famCrimeLangs['JOIN'],
@@ -1405,14 +1405,25 @@ class GetLanguageContent
             'QUIT' => $this->familyRaidLangs()['QUIT'],
             'RESULTS' => "Results",
             'RACE_TYPE' => "Race type",
+            'PLAYERS_REQUIRED' => "Players required",
+            'OPEN_RACES' => "Open streetraces",
+            'NO_OPEN_RACES' => "There are no streetraces waiting for opponents right now.",
+            'CURRENT_RACE' => "Your streetrace",
+            'NO_CURRENT_RACE' => "You are not participating in a streetrace right now.",
+            'LATEST_RACE' => "Latest streetrace",
+            'POSITION' => "Position",
+            'SCORE' => "Score",
+            'PRIZE' => "Prize",
             'NO_VEHICLE_TO_RACE' => "You don't have a vehicle available in your garages.",
             'ALREADY_PART_OF_RACE' => "You're already part of a ".strtolower($str)."!",
             'NO_PART_OF_RACE' => "You're not part yet of a ".strtolower($str)."!",
             'INVALID_RACE' => "You've choosen an invalid ".strtolower($str)."!",
             'INVALID_RACE_TYPE' => "You've choosen an invalid race type!",
             'INVALID_STAKE' => "You've choosen an invalid stake!",
+            'INVALID_PLAYER_COUNT' => "You've choosen an invalid amount of players!",
             'INVALID_VEHICLE' => "You've choosen an unknown vehicle!",
             'RACE_ALREADY_FULL' => "This ".strtolower($str)." is already full!",
+            'NOT_IN_SAME_STATE' => "You're not in the same state as this ".strtolower($str)."!",
             'RACE_NOT_READY_YET' => "This ".strtolower($str)." is not ready yet to be started!",
             'ORGANIZE_RACE_SUCCESS' => "You started a ".strtolower($str)."!",
             'JOIN_RACE_SUCCESS' => "You are now participating in this ".strtolower($str)."!",
@@ -1420,7 +1431,8 @@ class GetLanguageContent
             'LEAVE_RACE_SUCCESS' => "You left the ".strtolower($str)."!",
             'RACE_SUCCESS_LOST_NTH' => "You finished {nth} in the ".strtolower($str)." and lost your stake!",
             'RACE_SUCCESS_EVEN_SECOND' => "You finished second in the ".strtolower($str)." and won back your stake!",
-            'RACE_SUCCESS_WON_FIRST' => "You finished first place in the ".strtolower($str)." and won $&#8203;{price} cash!"
+            'RACE_SUCCESS_WON_FIRST' => "You finished first place in the ".strtolower($str)." and won $&#8203;{price} cash!",
+            'RACE_SUCCESS_WON_NTH' => "You finished {nth} in the ".strtolower($str)." and won $&#8203;{price} cash!"
         );
         return $langs;
     }

--- a/public_html/src/Languages/lang.nl.php
+++ b/public_html/src/Languages/lang.nl.php
@@ -1397,7 +1397,7 @@ class GetLanguageContent
         $famCrimeLangs = $this->familyCrimeLangs();
         $langs = array(
             'TITLE' => ucfirst($str),
-            'DESCRIPTION' => "Er zijn 4 soorten ".strtolower($str)."s: Highway, Route66, Drift Race en City Race.<br />Voor elk soort race moet je auto goed zijn op andere punten.<br /><br />De winnaar van de ".strtolower($str)." krijgt 3 keer de inzet, en de nummer 2 krijgt zijn inzet terug.<br />De nummer 3 en 4 verliezen hun geld.",
+            'DESCRIPTION' => "Streetraces kunnen nu worden georganiseerd voor meerdere spelers. Kies een racetype, het aantal vereiste spelers en bepaal je inzet.<br />Zodra de lobby vol is start de race automatisch. Het voertuig met de beste gecombineerde statistieken voor het gekozen racetype wint de race. Bij een gelijke stand wordt de winnaar willekeurig gekozen.",
             'ORGANIZE' => $famCrimeLangs['ORGANIZE'],
             'PARTICIPANTS' => $famCrimeLangs['PARTICIPANTS'],
             'JOIN' => $famCrimeLangs['JOIN'],
@@ -1405,14 +1405,25 @@ class GetLanguageContent
             'QUIT' => $this->familyRaidLangs()['QUIT'],
             'RESULTS' => "Uitslag",
             'RACE_TYPE' => "Race type",
+            'PLAYERS_REQUIRED' => "Benodigde spelers",
+            'OPEN_RACES' => "Open streetraces",
+            'NO_OPEN_RACES' => "Er wachten momenteel geen streetraces op tegenstanders.",
+            'CURRENT_RACE' => "Jouw streetrace",
+            'NO_CURRENT_RACE' => "Je neemt momenteel niet deel aan een streetrace.",
+            'LATEST_RACE' => "Laatste streetrace",
+            'POSITION' => "Positie",
+            'SCORE' => "Score",
+            'PRIZE' => "Prijs",
             'NO_VEHICLE_TO_RACE' => "Je hebt geen voertuig beschikbaar in jouw garages.",
             'ALREADY_PART_OF_RACE' => "Je doet al mee aan een ".strtolower($str)."!",
             'NO_PART_OF_RACE' => "Je doet nog niet mee aan een ".strtolower($str)."!",
             'INVALID_RACE' => "Je hebt een ongeldige ".strtolower($str)." opgegeven!",
             'INVALID_RACE_TYPE' => "Je hebt een ongeldig race type opgegeven!",
             'INVALID_STAKE' => "Je hebt een ongeldige inzet gekozen!",
+            'INVALID_PLAYER_COUNT' => "Je hebt een ongeldig aantal spelers gekozen!",
             'INVALID_VEHICLE' => "Je hebt een onbekend voertuig gekozen!",
             'RACE_ALREADY_FULL' => "Deze ".strtolower($str)." zit al vol!",
+            'NOT_IN_SAME_STATE' => "Je bevindt je niet in dezelfde staat als deze ".strtolower($str)."!",
             'RACE_NOT_READY_YET' => "Deze ".strtolower($str)." is nog niet klaar om te starten!",
             'ORGANIZE_RACE_SUCCESS' => "Je hebt een ".strtolower($str)." gestart!",
             'JOIN_RACE_SUCCESS' => "Je doet nu mee aan deze ".strtolower($str)."!",
@@ -1420,7 +1431,8 @@ class GetLanguageContent
             'LEAVE_RACE_SUCCESS' => "Je bent uit de ".strtolower($str)." gestapt!",
             'RACE_SUCCESS_LOST_NTH' => "Je bent {nth} geworden in de ".strtolower($str)." en je hebt je inzet verloren!",
             'RACE_SUCCESS_EVEN_SECOND' => "Je bent tweede geworden in de ".strtolower($str)." en je hebt je inzet teruggekregen!",
-            'RACE_SUCCESS_WON_FIRST' => "Je bent eerste geworden in de ".strtolower($str)." en je hebt $&#8203;{price} gewonnen!"
+            'RACE_SUCCESS_WON_FIRST' => "Je bent eerste geworden in de ".strtolower($str)." en je hebt $&#8203;{price} gewonnen!",
+            'RACE_SUCCESS_WON_NTH' => "Je bent {nth} geworden in de ".strtolower($str)." en je hebt $&#8203;{price} gewonnen!"
         );
         return $langs;
     }

--- a/public_html/src/Views/game/streetrace.twig
+++ b/public_html/src/Views/game/streetrace.twig
@@ -9,32 +9,180 @@
         <p class="center">{{ langs.DESCRIPTION|raw }}</p>
     </div>
     <div id="streetraceResponse"></div>
+
     {% if vehicles is not empty %}
-        <form class="ajaxForm center" method="POST" action="{{ routing.getAjaxRouteByRouteName('play-streetrace') }}" data-response="#streetraceResponse">
-            <input type="hidden" name="security-token" value="{{ securityToken }}" />
-            <div class="row">
-                {{ langs.VEHICLE }}:
-                <select name="vehicle">
-                    {% for g in vehicles %}
-                        <option value="{{ g.getId }}">{{ g.getVehicle.getName }}</option>
-                    {% endfor %}
-                </select>
+        <div class="row">
+            <div class="subtop">{{ langs.ORGANIZE }}</div>
+            <div class="content-container">
+                <form class="ajaxForm center" method="POST" action="{{ routing.getAjaxRouteByRouteName('play-streetrace') }}" data-response="#streetraceResponse">
+                    <input type="hidden" name="security-token" value="{{ securityToken }}" />
+                    <input type="hidden" name="action" value="organize" />
+                    <div class="row">
+                        {{ langs.VEHICLE }}:
+                        <select name="vehicle">
+                            {% for g in vehicles %}
+                                <option value="{{ g.getId }}">{{ g.getVehicle.getName }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="row">
+                        {{ langs.RACE_TYPE }}:
+                        <select name="type">
+                            {% for key, label in raceTypes %}
+                                <option value="{{ key }}">{{ label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="row">
+                        {{ langs.PLAYERS_REQUIRED }}:
+                        <select name="requiredPlayers">
+                            {% for amount in playerOptions %}
+                                <option value="{{ amount }}">{{ amount }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="row">
+                        {{ langs.STAKE }}:&nbsp;<input type="number" name="stake" placeholder="{{ langs.STAKE }}" />
+                        <input type="submit" name="streetrace" value="{{ langs.ORGANIZE }}" />
+                    </div>
+                </form>
             </div>
-            <div class="row">
-                {{ langs.RACE_TYPE }}:
-                <select name="type">
-                    {% for key, label in raceTypes %}
-                        <option value="{{ key }}">{{ label }}</option>
-                    {% endfor %}
-                </select>
-            </div>
-            <div class="row">
-                {{ langs.STAKE }}:&nbsp;<input type="number" name="stake" placeholder="{{ langs.STAKE }}" />
-                <input type="submit" name="streetrace" value="{{ langs.PLAY }}" />
-            </div>
-        </form>
+        </div>
     {% else %}
         <p class="center">{{ langs.NO_VEHICLE_TO_RACE }}</p>
+    {% endif %}
+
+    <div class="row">
+        <div class="subtop">{{ langs.OPEN_RACES }}</div>
+        <div class="content-container">
+            {% if openRaces is not empty %}
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>{{ langs.RACE_TYPE }}</th>
+                            <th>{{ langs.STAKE }}</th>
+                            <th>{{ langs.PLAYERS_REQUIRED }}</th>
+                            <th>{{ langs.PARTICIPANTS }}</th>
+                            <th>{{ langs.JOIN }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% set activeRaceId = userRace ? userRace.getId : 0 %}
+                        {% for race in openRaces %}
+                            <tr>
+                                <td>{{ raceTypes[race.getType]|default(race.getType|capitalize) }}</td>
+                                <td>$&#8203;{{ race.getStake|number_format(0, '', ',') }}</td>
+                                <td>{{ race.getRequiredPlayers }}</td>
+                                <td>{{ race.getParticipantCount }}/{{ race.getRequiredPlayers }}</td>
+                                <td class="center">
+                                    {% if activeRaceId > 0 %}
+                                        <em>{{ langs.ALREADY_PART_OF_RACE }}</em>
+                                    {% elseif race.getParticipantCount >= race.getRequiredPlayers %}
+                                        <em>{{ langs.RACE_ALREADY_FULL }}</em>
+                                    {% elseif vehicles is empty %}
+                                        <em>{{ langs.NO_VEHICLE_TO_RACE }}</em>
+                                    {% else %}
+                                        <form class="ajaxForm" method="POST" action="{{ routing.getAjaxRouteByRouteName('play-streetrace') }}" data-response="#streetraceResponse">
+                                            <input type="hidden" name="security-token" value="{{ securityToken }}" />
+                                            <input type="hidden" name="action" value="join" />
+                                            <input type="hidden" name="race" value="{{ race.getId }}" />
+                                            <select name="vehicle">
+                                                {% for g in vehicles %}
+                                                    <option value="{{ g.getId }}">{{ g.getVehicle.getName }}</option>
+                                                {% endfor %}
+                                            </select>
+                                            <input type="submit" value="{{ langs.JOIN }}" />
+                                        </form>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% else %}
+                <p class="center">{{ langs.NO_OPEN_RACES }}</p>
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="subtop">{{ langs.CURRENT_RACE }}</div>
+        <div class="content-container">
+            {% if userRace %}
+                <p class="center">{{ raceTypes[userRace.getType]|default(userRace.getType|capitalize) }} &mdash; $&#8203;{{ userRace.getStake|number_format(0, '', ',') }} &mdash; {{ userRace.getParticipantCount }}/{{ userRace.getRequiredPlayers }} {{ langs.PARTICIPANTS|lower }}</p>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>{{ langs.PARTICIPANTS }}</th>
+                            <th>{{ langs.VEHICLE }}</th>
+                            <th>{{ langs.SCORE }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for participant in userRace.getParticipants %}
+                            <tr>
+                                <td>{{ participant.getUsername }}</td>
+                                <td>{{ participant.getVehicleName }}</td>
+                                <td>
+                                    {% if participant.getScore > 0 %}
+                                        {{ participant.getScore|number_format(0, '', ',') }}
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <div class="center">
+                    <form class="ajaxForm inline" method="POST" action="{{ routing.getAjaxRouteByRouteName('play-streetrace') }}" data-response="#streetraceResponse">
+                        <input type="hidden" name="security-token" value="{{ securityToken }}" />
+                        <input type="hidden" name="action" value="leave" />
+                        <input type="hidden" name="race" value="{{ userRace.getId }}" />
+                        <input type="submit" value="{{ langs.LEAVE }}" />
+                    </form>
+                </div>
+            {% else %}
+                <p class="center">{{ langs.NO_CURRENT_RACE }}</p>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if lastResult %}
+        <div class="row">
+            <div class="subtop">{{ langs.LATEST_RACE }}</div>
+            <div class="content-container">
+                <p class="center">{{ raceTypes[lastResult.getType]|default(lastResult.getType|capitalize) }} &mdash; $&#8203;{{ lastResult.getStake|number_format(0, '', ',') }}</p>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>{{ langs.POSITION }}</th>
+                            <th>{{ langs.PARTICIPANTS }}</th>
+                            <th>{{ langs.VEHICLE }}</th>
+                            <th>{{ langs.SCORE }}</th>
+                            <th>{{ langs.PRIZE }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for participant in lastResult.getParticipants %}
+                            <tr>
+                                <td>{{ participant.getPosition }}</td>
+                                <td>{{ participant.getUsername }}</td>
+                                <td>{{ participant.getVehicleName }}</td>
+                                <td>{{ participant.getScore|number_format(0, '', ',') }}</td>
+                                <td>
+                                    {% if participant.getPrize > 0 %}
+                                        $&#8203;{{ participant.getPrize|number_format(0, '', ',') }}
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
     {% endif %}
 </div>
 {% endblock content %}


### PR DESCRIPTION
## Summary
- document and return the state-scoped streetrace overview along with the player’s open lobby and latest result
- ensure organizing, joining, and resolving races enforce state matching and deterministic scoring with payouts and notifications
- persist streetrace games/participants with state metadata while updating the Twig UI and language packs to manage lobbies and results

## Testing
- php -l public_html/src/Business/StreetraceService.php
- php -l public_html/src/Data/StreetraceDAO.php
- php -l public_html/src/Entities/Streetrace.php
- php -l public_html/src/Entities/StreetraceParticipant.php
- php -l public_html/src/Controllers/Ajax/streetrace.play.php
- php -l public_html/src/Controllers/game/streetrace.php
- php -l public_html/src/Languages/Notifications.php
- php -l public_html/src/Languages/lang.en.php
- php -l public_html/src/Languages/lang.nl.php

------
https://chatgpt.com/codex/tasks/task_b_68d909c872148324a4489f92f47812c8