### PR TITLE
Handle streetrace cleanup without DB cascade

### DIFF
--- a/public_html/install/config/clean-database.sql
+++ b/public_html/install/config/clean-database.sql
@@ -1593,8 +1593,7 @@ CREATE TABLE `streetrace_participant`  (
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE INDEX `unique_game_user`(`gameID`, `userID`) USING BTREE,
   INDEX `gameID_idx`(`gameID`) USING BTREE,
-  INDEX `userID_idx`(`userID`) USING BTREE,
-  CONSTRAINT `streetrace_participant_ibfk_1` FOREIGN KEY (`gameID`) REFERENCES `streetrace_game` (`id`) ON DELETE CASCADE
+  INDEX `userID_idx`(`userID`) USING BTREE
 ) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci ROW_FORMAT = COMPACT;
 
 -- ----------------------------


### PR DESCRIPTION
## Summary
- remove the streetrace participant foreign key from the install script while keeping useful indexes
- guard participant joins with a transactional lock so we only add players to races that still exist
- add a manual race deletion routine that clears participant rows when a race is emptied

## Testing
- php -l public_html/src/Data/StreetraceDAO.php

------
https://chatgpt.com/codex/tasks/task_b_68dafb51233c8324a70cd1d9686566e9