### PR TITLE
Adjust streetrace layout spacing and header styles

### DIFF
--- a/public_html/src/Views/game/streetrace.twig
+++ b/public_html/src/Views/game/streetrace.twig
@@ -6,212 +6,214 @@
         {{ langs.TITLE }}
     </div>
     <div class="content-container">
-        <div class="row">
-            <p class="center">{{ langs.DESCRIPTION|raw }}</p>
-        </div>
-        <div id="streetraceResponse"></div>
-
-        {% if vehicles is not empty %}
-            <div class="row" id="organizeStreetrace">
-                <div class="subtop">{{ langs.ORGANIZE }}</div>
-                <div class="content-container">
-                    <form class="ajaxForm" method="POST" action="{{ routing.getAjaxRouteByRouteName('play-streetrace') }}" data-response="#streetraceResponse">
-                        <input type="hidden" name="security-token" value="{{ securityToken }}" />
-                        <input type="hidden" name="action" value="organize" />
-                        <div class="row cols cf">
-                            <div class="c-30 column">
-                                <img src="{{ staticRoot }}/foto/web/public/images/icons/car.png" class="icon" alt="{{ langs.VEHICLE }}" /> {{ langs.VEHICLE }}
-                            </div>
-                            <div class="c-70 column">
-                                <select name="vehicle">
-                                    {% for g in vehicles %}
-                                        <option value="{{ g.getId }}">{{ g.getVehicle.getName }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                        </div>
-                        <div class="row cols cf">
-                            <div class="c-30 column">
-                                <img src="{{ staticRoot }}/foto/web/public/images/icons/flag_green.png" class="icon" alt="{{ langs.RACE_TYPE }}" /> {{ langs.RACE_TYPE }}
-                            </div>
-                            <div class="c-70 column">
-                                <select name="type">
-                                    {% for key, label in raceTypes %}
-                                        <option value="{{ key }}">{{ label }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                        </div>
-                        <div class="row cols cf">
-                            <div class="c-30 column">
-                                <img src="{{ staticRoot }}/foto/web/public/images/icons/group.png" class="icon" alt="{{ langs.PLAYERS_REQUIRED }}" /> {{ langs.PLAYERS_REQUIRED }}
-                            </div>
-                            <div class="c-70 column">
-                                <select name="requiredPlayers">
-                                    {% for amount in playerOptions %}
-                                        <option value="{{ amount }}">{{ amount }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                        </div>
-                        <div class="row cols cf">
-                            <div class="c-30 column">
-                                <img src="{{ staticRoot }}/foto/web/public/images/icons/coins.png" class="icon" alt="{{ langs.STAKE }}" /> {{ langs.STAKE }}
-                            </div>
-                            <div class="c-70 column">
-                                <input type="number" name="stake" placeholder="{{ langs.STAKE }}" min="1" max="2147483647" />
-                            </div>
-                        </div>
-                        <div class="row cf">
-                            <input type="submit" name="streetrace" class="right" value="{{ langs.ORGANIZE }}" />
-                        </div>
-                    </form>
-                </div>
+        <div class="inner-c-container">
+            <div class="row">
+                <p class="center">{{ langs.DESCRIPTION|raw }}</p>
             </div>
-        {% else %}
-            <p class="center">{{ langs.NO_VEHICLE_TO_RACE }}</p>
-        {% endif %}
+            <div id="streetraceResponse"></div>
 
-        <div class="row">
-            <div class="subtop">{{ langs.OPEN_RACES }}</div>
-            <div class="content-container">
-                {% if openRaces is not empty %}
-                    <div class="table-responsive">
-                        <table class="table table-sm table-dark table-bordered align-middle">
-                            <thead>
-                                <tr>
-                                    <th scope="col" class="center">{{ langs.STATE }}</th>
-                                    <th scope="col" class="center">{{ langs.RACE_TYPE }}</th>
-                                    <th scope="col" class="center">{{ langs.STAKE }}</th>
-                                    <th scope="col" class="center">{{ langs.PLAYERS_REQUIRED }}</th>
-                                    <th scope="col" class="center">{{ langs.PARTICIPANTS }}</th>
-                                    <th scope="col" class="center">{{ langs.JOIN }}</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% set activeRaceId = userRace ? userRace.getId : 0 %}
-                                {% for race in openRaces %}
-                                    <tr>
-                                        <td class="center">{{ race.getStateName|default('-') }}</td>
-                                        <td class="center">{{ raceTypes[race.getType]|default(race.getType|capitalize) }}</td>
-                                        <td class="center">$&#8203;{{ race.getStake|number_format(0, '', ',') }}</td>
-                                        <td class="center">{{ race.getRequiredPlayers }}</td>
-                                        <td class="center">{{ race.getParticipantCount }}/{{ race.getRequiredPlayers }}</td>
-                                        <td class="center">
-                                            {% if activeRaceId > 0 %}
-                                                <em>{{ langs.ALREADY_PART_OF_RACE }}</em>
-                                            {% elseif race.getParticipantCount >= race.getRequiredPlayers %}
-                                                <em>{{ langs.RACE_ALREADY_FULL }}</em>
-                                            {% elseif vehicles is empty %}
-                                                <em>{{ langs.NO_VEHICLE_TO_RACE }}</em>
-                                            {% else %}
-                                                <form class="ajaxForm inline" method="POST" action="{{ routing.getAjaxRouteByRouteName('play-streetrace') }}" data-response="#streetraceResponse">
-                                                    <input type="hidden" name="security-token" value="{{ securityToken }}" />
-                                                    <input type="hidden" name="action" value="join" />
-                                                    <input type="hidden" name="race" value="{{ race.getId }}" />
-                                                    <select name="vehicle">
-                                                        {% for g in vehicles %}
-                                                            <option value="{{ g.getId }}">{{ g.getVehicle.getName }}</option>
-                                                        {% endfor %}
-                                                    </select>
-                                                    <input type="submit" value="{{ langs.JOIN }}" />
-                                                </form>
-                                            {% endif %}
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+            {% if vehicles is not empty %}
+                <div class="row" id="organizeStreetrace">
+                    <div class="subtop">{{ langs.ORGANIZE }}</div>
+                    <div class="content-container">
+                        <form class="ajaxForm" method="POST" action="{{ routing.getAjaxRouteByRouteName('play-streetrace') }}" data-response="#streetraceResponse">
+                            <input type="hidden" name="security-token" value="{{ securityToken }}" />
+                            <input type="hidden" name="action" value="organize" />
+                            <div class="row cols cf">
+                                <div class="c-30 column">
+                                    <img src="{{ staticRoot }}/foto/web/public/images/icons/car.png" class="icon" alt="{{ langs.VEHICLE }}" /> {{ langs.VEHICLE }}
+                                </div>
+                                <div class="c-70 column">
+                                    <select name="vehicle">
+                                        {% for g in vehicles %}
+                                            <option value="{{ g.getId }}">{{ g.getVehicle.getName }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="row cols cf">
+                                <div class="c-30 column">
+                                    <img src="{{ staticRoot }}/foto/web/public/images/icons/flag_green.png" class="icon" alt="{{ langs.RACE_TYPE }}" /> {{ langs.RACE_TYPE }}
+                                </div>
+                                <div class="c-70 column">
+                                    <select name="type">
+                                        {% for key, label in raceTypes %}
+                                            <option value="{{ key }}">{{ label }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="row cols cf">
+                                <div class="c-30 column">
+                                    <img src="{{ staticRoot }}/foto/web/public/images/icons/group.png" class="icon" alt="{{ langs.PLAYERS_REQUIRED }}" /> {{ langs.PLAYERS_REQUIRED }}
+                                </div>
+                                <div class="c-70 column">
+                                    <select name="requiredPlayers">
+                                        {% for amount in playerOptions %}
+                                            <option value="{{ amount }}">{{ amount }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="row cols cf">
+                                <div class="c-30 column">
+                                    <img src="{{ staticRoot }}/foto/web/public/images/icons/coins.png" class="icon" alt="{{ langs.STAKE }}" /> {{ langs.STAKE }}
+                                </div>
+                                <div class="c-70 column">
+                                    <input type="number" name="stake" placeholder="{{ langs.STAKE }}" min="1" max="2147483647" />
+                                </div>
+                            </div>
+                            <div class="row cf">
+                                <input type="submit" name="streetrace" class="right" value="{{ langs.ORGANIZE }}" />
+                            </div>
+                        </form>
                     </div>
-                {% else %}
-                    <p class="center">{{ langs.NO_OPEN_RACES }}</p>
-                {% endif %}
-            </div>
-        </div>
-
-    <div class="row">
-        <div class="subtop">{{ langs.CURRENT_RACE }}</div>
-        <div class="content-container">
-            {% if userRace %}
-                <p class="center">{{ userRace.getStateName|default('-') }} &mdash; {{ raceTypes[userRace.getType]|default(userRace.getType|capitalize) }} &mdash; $&#8203;{{ userRace.getStake|number_format(0, '', ',') }} &mdash; {{ userRace.getParticipantCount }}/{{ userRace.getRequiredPlayers }} {{ langs.PARTICIPANTS|lower }}</p>
-                <div class="table-responsive">
-                    <table class="table table-sm table-dark table-bordered align-middle">
-                        <thead>
-                            <tr>
-                                <th scope="col" class="center">{{ langs.PARTICIPANTS }}</th>
-                                <th scope="col" class="center">{{ langs.VEHICLE }}</th>
-                                <th scope="col" class="center">{{ langs.SCORE }}</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for participant in userRace.getParticipants %}
-                                <tr>
-                                    <td class="center">{{ participant.getUsername }}</td>
-                                    <td class="center">{{ participant.getVehicleName }}</td>
-                                    <td class="center">
-                                        {% if participant.getScore > 0 %}
-                                            {{ participant.getScore|number_format(0, '', ',') }}
-                                        {% else %}
-                                            -
-                                        {% endif %}
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                <div class="center">
-                    <form class="ajaxForm inline" method="POST" action="{{ routing.getAjaxRouteByRouteName('play-streetrace') }}" data-response="#streetraceResponse">
-                        <input type="hidden" name="security-token" value="{{ securityToken }}" />
-                        <input type="hidden" name="action" value="leave" />
-                        <input type="hidden" name="race" value="{{ userRace.getId }}" />
-                        <input type="submit" value="{{ langs.LEAVE }}" />
-                    </form>
                 </div>
             {% else %}
-                <p class="center">{{ langs.NO_CURRENT_RACE }}</p>
+                <p class="center">{{ langs.NO_VEHICLE_TO_RACE }}</p>
             {% endif %}
-        </div>
-    </div>
 
-        {% if lastResult %}
             <div class="row">
-                <div class="subtop">{{ langs.LATEST_RACE }}</div>
+                <div class="subtop">{{ langs.OPEN_RACES }}</div>
                 <div class="content-container">
-                    <p class="center">{{ lastResult.getStateName|default('-') }} &mdash; {{ raceTypes[lastResult.getType]|default(lastResult.getType|capitalize) }} &mdash; $&#8203;{{ lastResult.getStake|number_format(0, '', ',') }}</p>
-                    <div class="table-responsive">
-                        <table class="table table-sm table-dark table-bordered align-middle">
-                            <thead>
-                                <tr>
-                                    <th scope="col" class="center">{{ langs.POSITION }}</th>
-                                    <th scope="col" class="center">{{ langs.PARTICIPANTS }}</th>
-                                    <th scope="col" class="center">{{ langs.VEHICLE }}</th>
-                                    <th scope="col" class="center">{{ langs.SCORE }}</th>
-                                    <th scope="col" class="center">{{ langs.PRIZE }}</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for participant in lastResult.getParticipants %}
+                    {% if openRaces is not empty %}
+                        <div class="table-responsive">
+                            <table class="table table-sm table-dark table-bordered align-middle">
+                                <thead>
                                     <tr>
-                                        <td class="center">{{ participant.getPosition }}</td>
-                                        <td class="center">{{ participant.getUsername }}</td>
-                                        <td class="center">{{ participant.getVehicleName }}</td>
-                                        <td class="center">{{ participant.getScore|number_format(0, '', ',') }}</td>
-                                        <td class="center">
-                                            {% if participant.getPrize > 0 %}
-                                                $&#8203;{{ participant.getPrize|number_format(0, '', ',') }}
-                                            {% else %}
-                                                -
-                                            {% endif %}
-                                        </td>
+                                        <th scope="col" class="center"><small>{{ langs.STATE }}</small></th>
+                                        <th scope="col" class="center"><small>{{ langs.RACE_TYPE }}</small></th>
+                                        <th scope="col" class="center"><small>{{ langs.STAKE }}</small></th>
+                                        <th scope="col" class="center"><small>{{ langs.PLAYERS_REQUIRED }}</small></th>
+                                        <th scope="col" class="center"><small>{{ langs.PARTICIPANTS }}</small></th>
+                                        <th scope="col" class="center"><small>{{ langs.JOIN }}</small></th>
                                     </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody>
+                                    {% set activeRaceId = userRace ? userRace.getId : 0 %}
+                                    {% for race in openRaces %}
+                                        <tr>
+                                            <td class="center">{{ race.getStateName|default('-') }}</td>
+                                            <td class="center">{{ raceTypes[race.getType]|default(race.getType|capitalize) }}</td>
+                                            <td class="center">$&#8203;{{ race.getStake|number_format(0, '', ',') }}</td>
+                                            <td class="center">{{ race.getRequiredPlayers }}</td>
+                                            <td class="center">{{ race.getParticipantCount }}/{{ race.getRequiredPlayers }}</td>
+                                            <td class="center">
+                                                {% if activeRaceId > 0 %}
+                                                    <em>{{ langs.ALREADY_PART_OF_RACE }}</em>
+                                                {% elseif race.getParticipantCount >= race.getRequiredPlayers %}
+                                                    <em>{{ langs.RACE_ALREADY_FULL }}</em>
+                                                {% elseif vehicles is empty %}
+                                                    <em>{{ langs.NO_VEHICLE_TO_RACE }}</em>
+                                                {% else %}
+                                                    <form class="ajaxForm inline" method="POST" action="{{ routing.getAjaxRouteByRouteName('play-streetrace') }}" data-response="#streetraceResponse">
+                                                        <input type="hidden" name="security-token" value="{{ securityToken }}" />
+                                                        <input type="hidden" name="action" value="join" />
+                                                        <input type="hidden" name="race" value="{{ race.getId }}" />
+                                                        <select name="vehicle">
+                                                            {% for g in vehicles %}
+                                                                <option value="{{ g.getId }}">{{ g.getVehicle.getName }}</option>
+                                                            {% endfor %}
+                                                        </select>
+                                                        <input type="submit" value="{{ langs.JOIN }}" />
+                                                    </form>
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
                     </div>
+                    {% else %}
+                        <p class="center">{{ langs.NO_OPEN_RACES }}</p>
+                    {% endif %}
                 </div>
             </div>
-        {% endif %}
+
+            <div class="row">
+                <div class="subtop">{{ langs.CURRENT_RACE }}</div>
+                <div class="content-container">
+                    {% if userRace %}
+                        <p class="center">{{ userRace.getStateName|default('-') }} &mdash; {{ raceTypes[userRace.getType]|default(userRace.getType|capitalize) }} &mdash; $&#8203;{{ userRace.getStake|number_format(0, '', ',') }} &mdash; {{ userRace.getParticipantCount }}/{{ userRace.getRequiredPlayers }} {{ langs.PARTICIPANTS|lower }}</p>
+                        <div class="table-responsive">
+                            <table class="table table-sm table-dark table-bordered align-middle">
+                                <thead>
+                                    <tr>
+                                        <th scope="col" class="center"><small>{{ langs.PARTICIPANTS }}</small></th>
+                                        <th scope="col" class="center"><small>{{ langs.VEHICLE }}</small></th>
+                                        <th scope="col" class="center"><small>{{ langs.SCORE }}</small></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for participant in userRace.getParticipants %}
+                                        <tr>
+                                            <td class="center">{{ participant.getUsername }}</td>
+                                            <td class="center">{{ participant.getVehicleName }}</td>
+                                            <td class="center">
+                                                {% if participant.getScore > 0 %}
+                                                    {{ participant.getScore|number_format(0, '', ',') }}
+                                                {% else %}
+                                                    -
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="center">
+                            <form class="ajaxForm inline" method="POST" action="{{ routing.getAjaxRouteByRouteName('play-streetrace') }}" data-response="#streetraceResponse">
+                                <input type="hidden" name="security-token" value="{{ securityToken }}" />
+                                <input type="hidden" name="action" value="leave" />
+                                <input type="hidden" name="race" value="{{ userRace.getId }}" />
+                                <input type="submit" value="{{ langs.LEAVE }}" />
+                            </form>
+                        </div>
+                    {% else %}
+                        <p class="center">{{ langs.NO_CURRENT_RACE }}</p>
+                    {% endif %}
+                </div>
+            </div>
+
+            {% if lastResult %}
+                <div class="row">
+                    <div class="subtop">{{ langs.LATEST_RACE }}</div>
+                    <div class="content-container">
+                        <p class="center">{{ lastResult.getStateName|default('-') }} &mdash; {{ raceTypes[lastResult.getType]|default(lastResult.getType|capitalize) }} &mdash; $&#8203;{{ lastResult.getStake|number_format(0, '', ',') }}</p>
+                        <div class="table-responsive">
+                            <table class="table table-sm table-dark table-bordered align-middle">
+                                <thead>
+                                    <tr>
+                                        <th scope="col" class="center"><small>{{ langs.POSITION }}</small></th>
+                                        <th scope="col" class="center"><small>{{ langs.PARTICIPANTS }}</small></th>
+                                        <th scope="col" class="center"><small>{{ langs.VEHICLE }}</small></th>
+                                        <th scope="col" class="center"><small>{{ langs.SCORE }}</small></th>
+                                        <th scope="col" class="center"><small>{{ langs.PRIZE }}</small></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for participant in lastResult.getParticipants %}
+                                        <tr>
+                                            <td class="center">{{ participant.getPosition }}</td>
+                                            <td class="center">{{ participant.getUsername }}</td>
+                                            <td class="center">{{ participant.getVehicleName }}</td>
+                                            <td class="center">{{ participant.getScore|number_format(0, '', ',') }}</td>
+                                            <td class="center">
+                                                {% if participant.getPrize > 0 %}
+                                                    $&#8203;{{ participant.getPrize|number_format(0, '', ',') }}
+                                                {% else %}
+                                                    -
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+        </div>
     </div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
## Summary
- wrap the top streetrace content in an inner container so the description and controls align with padding used elsewhere
- shrink the table header text for the open, current, and latest race tables to match the rest of the UI

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_b_68dda156093c8324a3b7f6223ba0636d